### PR TITLE
Update versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.0.*|5.1.*|5.2.*"
+        "illuminate/support": "~5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7.6"


### PR DESCRIPTION
When you do ~5.0 it means, you're supporting 5.1 & 5.2 automatically. It translates to: >=5.0.0,<6.0.0. So all the minor/patches are covered.