### PR TITLE
Route definition re-ordered

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,8 +303,8 @@ Edit the `app\Http\routes.php` file.
 - Define two (2) new routes.
 
 ```
-    Route::get('verification/{token}', 'Auth\AuthController@getVerification');
     Route::get('verification/error', 'Auth\AuthController@getVerificationError');
+    Route::get('verification/{token}', 'Auth\AuthController@getVerification');
 ```
 
 - Define the e-mail view.


### PR DESCRIPTION
When I define the `verification/{token}` route before browser throws me redirect loop error instead of displaying `verification/error` when handling invalid tokens. In this case, route `verification/{token}` overrides `verification/error`. So It must be re-ordered