### PR TITLE
add error page view & publish methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,13 +187,15 @@ No user found for the given e-mail adresse.
 
 ### Error View
 
-Create a view for the default verification error route `/verification/error` at
-`resources/views/errors/user-verification.blade.php`. If an error occurs, the
-user will be redirected to this route and this view will be rendered. **You
-must implement and customize this view to your needs.** For instance you may
-wish to display a short message saying that something went wrong and then ask
-for the user's e-mail again and start the process from scratch (generate, send,
-verify, ...).
+By default the `user-verification.blade.php` view will be used for the verification error route `/verification/error`. If an error occurs, the user will be redirected to this route and this view will be rendered.
+
+**You may customize this view to your needs.** To do so first publish the view to your resources folder:
+
+```
+    php artisan vendor:publish --tag=laravel-user-verification-views
+```
+
+Now the view will be available in your `resources/views/vendor/laravel-user-verification/` directory and can be customized.
 
 ## Usage
 

--- a/src/Traits/VerifiesUsers.php
+++ b/src/Traits/VerifiesUsers.php
@@ -74,7 +74,7 @@ trait VerifiesUsers
      */
     protected function verificationErrorView()
     {
-        return property_exists($this, 'verificationErrorView') ? $this->verificationErrorView : 'errors.user-verification';
+        return property_exists($this, 'verificationErrorView') ? $this->verificationErrorView : 'laravel-user-verification::user-verification';
     }
 
     /**

--- a/src/UserVerificationServiceProvider.php
+++ b/src/UserVerificationServiceProvider.php
@@ -12,6 +12,19 @@ use Illuminate\Support\ServiceProvider;
 class UserVerificationServiceProvider extends ServiceProvider
 {
     /**
+     * Perform post-registration booting of services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'laravel-user-verification');
+
+        $this->publishes([
+                __DIR__.'/../resources/views' => base_path('resources/views/vendor/laravel-user-verification'),
+            ], 'laravel-user-verification-views');
+    }
+    /**
      * Register the service provider.
      *
      * @return void

--- a/src/resources/views/user-verification.blade.php
+++ b/src/resources/views/user-verification.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.app')
+
+<!-- Main Content -->
+@section('content')
+<div class="container">
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+            <div class="panel panel-default">
+                <div class="panel-heading">Verification failed</div>
+                <div class="panel-body">
+                    <span class="help-block">
+                        <strong>Your account could not be verified.</strong>
+                    </span>
+                    <div class="form-group">
+                        <div class="col-md-12">
+                            <a href="{{url('/')}}" class="btn btn-primary">
+                                Back
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection


### PR DESCRIPTION
Now by default the view that is provided with the package will be used.

Additionally the user can publish the view and customize it.

I would recommend removing the `verificationErrorView` variable from the `trait` as it is not needed anymore. This also means the whole `protected function verificationErrorView()` method could be removed in the future.

Also the same change should be done for the email template. Laravel ships with email templates when using notifications, which would be a good change. https://laravel.com/docs/5.3/notifications#formatting-mail-messages