### PR TITLE
Fire VerificationEmailSent Event

### DIFF
--- a/src/Events/VerificationEmailSent.php
+++ b/src/Events/VerificationEmailSent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Jrean\UserVerification\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class VerificationEmailSent
+{
+    use SerializesModels;
+
+    /**
+     * The authenticated user.
+     *
+     * @var \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return void
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/src/UserVerification.php
+++ b/src/UserVerification.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Database\Schema\Builder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Jrean\UserVerification\Events\VerificationEmailSent;
 use Jrean\UserVerification\Exceptions\ModelNotCompliantException;
 use Jrean\UserVerification\Exceptions\UserNotFoundException;
 use Jrean\UserVerification\Exceptions\UserIsVerifiedException;
@@ -337,6 +338,8 @@ class UserVerification
             $m->to($user->email);
 
             $m->subject(is_null($subject) ? trans('laravel-user-verification::user-verification.verification_email_subject') : $subject);
+
+            event(new VerificationEmailSent($user));
         });
     }
 
@@ -359,6 +362,8 @@ class UserVerification
             $m->to($user->email);
 
             $m->subject(is_null($subject) ? trans('laravel-user-verification::user-verification.verification_email_subject') : $subject);
+
+            event(new VerificationEmailSent($user));
         });
     }
 
@@ -382,6 +387,8 @@ class UserVerification
             $m->to($user->email);
 
             $m->subject(is_null($subject) ? trans('laravel-user-verification::user-verification.verification_email_subject') : $subject);
+
+            event(new VerificationEmailSent($user));
         });
     }
 
@@ -405,6 +412,8 @@ class UserVerification
             $m->to($user->email);
 
             $m->subject(is_null($subject) ? trans('laravel-user-verification::user-verification.verification_email_subject') : $subject);
+
+            event(new VerificationEmailSent($user));
         });
     }
 
@@ -428,6 +437,8 @@ class UserVerification
             $m->to($user->email);
 
             $m->subject(is_null($subject) ? trans('laravel-user-verification::user-verification.verification_email_subject') : $subject);
+
+            event(new VerificationEmailSent($user));
         });
     }
 


### PR DESCRIPTION
This PR adds an event that is fire once the verification email is sent.

This can be very useful for example when you want to log the fact that the email was sent. Or if you want to store a timestamp so that you can wait for x minutes until you remind the user again, to verify the email...