### PR TITLE
Add phpunit + trait test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: php
+
+sudo: false
+
+matrix:
+  include:
+    - php: 5.5
+    - php: 5.6
+      env:
+        - EXECUTE_COVERAGE=true
+    - php: 7.0
+  fast_finish: true
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+install:
+  - travis_retry composer install --prefer-dist
+
+script:
+  - mkdir -p build/logs
+  - if [ "$EXECUTE_COVERAGE" != "true" ]; then composer test; fi
+  - if [ "$EXECUTE_COVERAGE" == "true" ]; then composer run travis; fi
+
+after_success:
+  - travis_retry php vendor/bin/coveralls

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,20 @@
         "preferred-install": "dist"
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "require-dev": {
+        "phpunit/phpunit": "^5.5",
+        "fzaninotto/faker": "^1.6",
+        "mockery/mockery": "^0.9.5",
+        "satooshi/php-coveralls": "^1.0"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Jrean\\UserVerification\\Tests\\": "tests"
+        }
+    },
+    "scripts": {
+        "test": "phpunit --colors=always;",
+        "travis": "phpunit --coverage-clover build/logs/clover.xml"
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jrean\UserVerification\Tests;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Application;
+use PHPUnit_Framework_TestCase;
+
+abstract class TestCase extends PHPUnit_Framework_TestCase
+{
+
+    public function setUp()
+    {
+        parent::setUp();
+        // add any setup functions here
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        // add any tearDown functions here
+    }
+}

--- a/tests/TestUser.php
+++ b/tests/TestUser.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Jrean\UserVerification\Tests;
+
+use Jrean\UserVerification\Traits\UserVerification;
+
+class TestUser{
+    use UserVerification;
+
+    protected $verified;
+    protected $verification_token;
+
+    public function __construct($verified = 0, $token = null)
+    {
+        $this->verified = $verified;
+        $this->verification_token = $token;
+    }
+}

--- a/tests/TraitUserVerificationTest.php
+++ b/tests/TraitUserVerificationTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Jrean\UserVerification\Tests;
+
+use Jrean\UserVerification\Tests\TestCase;
+use Jrean\UserVerification\Tests\TestUser;
+
+class TraitUserVerificationTest extends TestCase
+{
+    /** @test **/
+    public function user_is_not_verified()
+    {
+        $user = new TestUser(0,null);
+        $this->assertEquals($user->isVerified(), false);
+    }
+
+    /** @test **/
+    public function user_is_verified()
+    {
+        $user = new TestUser(1,null);
+        $this->assertEquals($user->isVerified(), true);
+    }
+
+    /** @test **/
+    public function user_is_pending()
+    {
+        $user = new TestUser(0,'123456');
+        $this->assertEquals($user->isPendingVerification(), true);
+    }
+
+    /** @test **/
+    public function user_is_not_pending_already_verified()
+    {
+        $user = new TestUser(1,'123456');
+        $this->assertEquals($user->isPendingVerification(), false);
+    }
+
+    /** @test **/
+    public function user_is_not_pending_no_token()
+    {
+        $user = new TestUser(0,null);
+        $this->assertEquals($user->isPendingVerification(), false);
+    }
+
+}


### PR DESCRIPTION
This adds a the phpunit framework and a first test. This is a start to fix #36.

I included:
- fzaninotto/faker
- mockery/mockery

as they might come in handy for the other tests. If we have a test coverage of 100% (or close) and don't need them, we can remove them. They are added to the `dev-requirements` in any case.

I also included `satooshi/php-coveralls` which will push the coverage report from travis-ci to coveralls.io once you set that up.

I added a `.travis.yml` file. I hope it is fine like this, but I find it always hard to do it without being able to try it out, so please set those accounts up.

Once you merge #64 there will be a merge conflict in this line https://github.com/jrean/laravel-user-verification/compare/master...veare:phpunit#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780R38

However you can easily resolve it by replacing the line with this one:

```
"test": "phpunit --colors=always; ./vendor/bin/php-cs-fixer fix src --diff --dry-run --ansi;"
```