### PR TITLE
Refactor email

### DIFF
--- a/src/UserVerification.php
+++ b/src/UserVerification.php
@@ -331,15 +331,9 @@ class UserVerification
     protected function emailVerificationLink(AuthenticatableContract $user, $subject, $from = null, $name = null)
     {
         return $this->mailer->send($this->emailView, compact('user'), function ($m) use ($user, $subject, $from, $name) {
-            if (! empty($from)) {
-                $m->from($from, $name);
-            }
 
-            $m->to($user->email);
+            $m = $this->createVerificationEmail($m, $user, $subject, $from, $name);
 
-            $m->subject(is_null($subject) ? trans('laravel-user-verification::user-verification.verification_email_subject') : $subject);
-
-            event(new VerificationEmailSent($user));
         });
     }
 
@@ -355,15 +349,9 @@ class UserVerification
     protected function emailQueueVerificationLink(AuthenticatableContract $user, $subject, $from = null, $name = null)
     {
         return $this->mailer->queue($this->emailView, compact('user'), function ($m) use ($user, $subject, $from, $name) {
-            if (! empty($from)) {
-                $m->from($from, $name);
-            }
 
-            $m->to($user->email);
+            $m = $this->createVerificationEmail($m, $user, $subject, $from, $name);
 
-            $m->subject(is_null($subject) ? trans('laravel-user-verification::user-verification.verification_email_subject') : $subject);
-
-            event(new VerificationEmailSent($user));
         });
     }
 
@@ -380,15 +368,9 @@ class UserVerification
     protected function emailQueueOnVerificationLink($queue, AuthenticatableContract $user, $subject, $from = null, $name = null)
     {
         return $this->mailer->queueOn($queue, $this->emailView, compact('user'), function ($m) use ($user, $subject, $from, $name) {
-            if (! empty($from)) {
-                $m->from($from, $name);
-            }
 
-            $m->to($user->email);
+            $m = $this->createVerificationEmail($m, $user, $subject, $from, $name);
 
-            $m->subject(is_null($subject) ? trans('laravel-user-verification::user-verification.verification_email_subject') : $subject);
-
-            event(new VerificationEmailSent($user));
         });
     }
 
@@ -405,15 +387,9 @@ class UserVerification
     protected function emailLaterVerificationLink($seconds, AuthenticatableContract $user, $subject, $from = null, $name = null)
     {
         return $this->mailer->later($seconds, $this->emailView, compact('user'), function ($m) use ($user, $subject, $from, $name) {
-            if (! empty($from)) {
-                $m->from($from, $name);
-            }
 
-            $m->to($user->email);
+            $m = $this->createVerificationEmail($m, $user, $subject, $from, $name);
 
-            $m->subject(is_null($subject) ? trans('laravel-user-verification::user-verification.verification_email_subject') : $subject);
-
-            event(new VerificationEmailSent($user));
         });
     }
 
@@ -430,16 +406,35 @@ class UserVerification
     protected function emailLaterOnVerificationLink($queue, $seconds, AuthenticatableContract $user, $subject, $from = null, $name = null)
     {
         return $this->mailer->laterOn($queue, $seconds, $this->emailView, compact('user'), function ($m) use ($user, $subject, $from, $name) {
-            if (! empty($from)) {
-                $m->from($from, $name);
-            }
 
-            $m->to($user->email);
+            $m = $this->createVerificationEmail($m, $user, $subject, $from, $name);
 
-            $m->subject(is_null($subject) ? trans('laravel-user-verification::user-verification.verification_email_subject') : $subject);
-
-            event(new VerificationEmailSent($user));
         });
+    }
+
+    /**
+     * creates the email to be send out
+     * @method createVerificationEmail
+     * @param  string                  $mail
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  string                  $subject
+     * @param  string                  $from    [description]
+     * @param  string                  $name    [description]
+     * @return [type]                           [description]
+     */
+    protected function createVerificationEmail($mail, $user, $subject, $from, $name)
+    {
+        if (! empty($from)) {
+            $mail->from($from, $name);
+        }
+
+        $mail->to($user->email);
+
+        $mail->subject(is_null($subject) ? trans('laravel-user-verification::user-verification.verification_email_subject') : $subject);
+
+        event(new VerificationEmailSent($user));
+
+        return $mail;
     }
 
     /**


### PR DESCRIPTION
This fixes #53. I only tested it with normal emails, so please test queues as well.

This is just a bit so that we can more easily do changes with email, like in #70, because we only need to change it in one place.

We should still consider moving to https://laravel.com/docs/5.3/notifications in the near future.