### PR TITLE
Add route middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,35 @@ To customize the migration(s) to your needs, publish them with the following com
 php artisan vendor:publish --provider="Jrean\UserVerification\UserVerificationServiceProvider" --tag="migrations"
 ```
 
+## Middleware
+
+### Default middleware
+This package ships with an optional middleware which throws a `UserNotVerifiedException`. You can setup the desired behaviour, for example a redirect to a specific page, in the `app\Exceptions\Handler.php`. Please refer to the [Laravel Documentation](https://laravel.com/docs/master/errors#the-exception-handler) to learn more about how to work with the exception handler.
+
+To register the default middleware add the following to the `$routeMiddleware` array within the `app/Kernal.php` file:
+
+```php
+protected $routeMiddleware = [
+    // …
+    'isVerified' => Jrean\UserVerification\Middleware\IsVerified::class,
+```
+
+Now you can use the middleware on your routes:
+
+```php
+Route::group(['middleware' => ['web', 'isVerified']], function () {
+    …
+```
+
+### Custom middleware
+Instead of using the provided middleware you can create your own middleware using artisan:
+
+```
+php artisan make:middleware IsVerified
+```
+
+For more information on middleware please refer to the Please refer to the [Laravel Documentation](https://laravel.com/docs/5.3/middleware) to learn more about how to work with the exception handler.
+
 ## E-MAIL
 
 This package provides a method to send an e-mail with a link containing the verification token.
@@ -158,6 +187,10 @@ Wrong verification token.
 * `UserIsVerifiedException`
 
 The given user is already verified.
+
+* `UserNotVerifiedException`
+
+The given user is not verified yet.
 
 * `UserNotFoundException`
 

--- a/src/Exceptions/UserNotVerifiedException.php
+++ b/src/Exceptions/UserNotVerifiedException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of Jrean\UserVerification package.
+ *
+ * (c) Jean Ragouin <go@askjong.com> <www.askjong.com>
+ */
+namespace Jrean\UserVerification\Exceptions;
+
+use Exception;
+
+class UserNotVerifiedException extends Exception
+{
+    /**
+     * The exception description.
+     *
+     * @var string
+     */
+    protected $message = 'This user is not verified.';
+}

--- a/src/Middleware/IsVerified.php
+++ b/src/Middleware/IsVerified.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Jrean\UserVerification\Middleware;
+
+use Closure;
+use Jrean\UserVerification\Exceptions\UserNotVerifiedException;
+
+class IsVerified
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     *
+     * @throws Jrean\UserVerification\Exceptions\UserNotVerifiedException
+     */
+    public function handle($request, Closure $next)
+    {
+        if( $request->user()->verified !== 1 ){
+            throw new UserNotVerifiedException;
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
This PR adds a simple middleware as discussed in #76. 

By default the middleware throws a new `UserNotVerifiedException` which the user can deal with in the `Handler.php` (this is a typical laravel behaviour and is done for example for the Authorize middleware as well).

However the user is free create a completly custom middleware.

The user needs to register the middleware in the `Kernal.php` file, this means, if the suer just updates the package nothing will happen at all, as the middleware is not automatically loaded.

To use the middleware once it is registered it needs to be applied to a route, like the `auth` middleware.