### PR TITLE
More accurate UserVerification Trait

### DIFF
--- a/src/Traits/UserVerification.php
+++ b/src/Traits/UserVerification.php
@@ -15,7 +15,7 @@ trait UserVerification
      */
     public function isVerified()
     {
-        return $this->verified === 1;
+        return (bool) $this->verified;
     }
 
     /**
@@ -25,6 +25,16 @@ trait UserVerification
      */
     public function isPendingVerification()
     {
-        return $this->verified === 0 && $this->verification_token !== null;
+        return ! $this->isVerified() && $this->hasVerificationToken();
+    }
+    
+    /**
+     * Checks if the user has verification token.
+     *
+     * @return bool
+     */
+    public function hasVerificationToken()
+    {
+        return ! is_null($this->verification_token);
     }
 }


### PR DESCRIPTION
I encountered a problem with the `UserVerification` Trait the `===` was restricting the `$this->verified` to always be an integer. I was using sqlite for my database in my unit tests and $this->verified was returned as string, hence my tests were failing.

I think this quick fix can help solve this problem. I also added a quick method specifically for checking if verification token is present and updated the `isPendingVerification()` method to reuse those methods.
