### PR TITLE
Add use statement for various @return docblocks

### DIFF
--- a/src/Traits/VerifiesUsers.php
+++ b/src/Traits/VerifiesUsers.php
@@ -6,6 +6,7 @@
  */
 namespace Jrean\UserVerification\Traits;
 
+use Illuminate\Http\Response;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 use Jrean\UserVerification\Facades\UserVerification as UserVerificationFacade;


### PR DESCRIPTION
Addresses issue #131 

Since Illuminate\Http\Response isn't directly used by the trait, an alternative approach would have all relevant docblocks which presently have

`@return Response`
instead be changed to
`@return \Illuminate\Http\Response`