### PR TITLE
Support Laravel 5.5 auto-discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,15 @@
         }
     },
     "scripts": {
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Jrean\\UserVerification\\UserVerificationServiceProvider"
+            ],
+            "aliases": {
+                "UserVerification": "Jrean\\UserVerification\\Facades\\UserVerification"
+            }
+        }
     }
 }


### PR DESCRIPTION
Added support for Laravel 5.5 auto-discovery inside `composer.json` file, by pointing to the correct ServiceProvider and Facade.