### PR TITLE
Use correct namespace

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -14,9 +14,9 @@
 Route::group([
     'middleware' => 'web'
 ], function () {
-    Route::get('email-verification/error', 'App\Http\Controllers\Auth\RegisterController@getVerificationError')
+    Route::get('email-verification/error', 'Auth\RegisterController@getVerificationError')
         ->name('email-verification.error');
 
-    Route::get('email-verification/check/{token}', 'App\Http\Controllers\Auth\RegisterController@getVerification')
+    Route::get('email-verification/check/{token}', 'Auth\RegisterController@getVerification')
         ->name('email-verification.check');
 });


### PR DESCRIPTION
All controllers are already prefixed with `App\Http\Controllers`, therefore it has to be removed here. See also `vendor/laravel/framework/src/Illuminate/Routing/Router.php`:

```php
// Authentication Routes...
$this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
$this->post('login', 'Auth\LoginController@login');
$this->post('logout', 'Auth\LoginController@logout')->name('logout');
```