### PR TITLE
Add Laravel 5.7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "illuminate/support": "5.6.*"
+        "illuminate/support": "5.7.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Require "illuminate/support": "5.7.*"