### PR TITLE
set stdclass type in Mongo DB

### DIFF
--- a/src/UserVerification.php
+++ b/src/UserVerification.php
@@ -275,7 +275,7 @@ class UserVerification
         if ($user === null) {
             throw new UserNotFoundException();
         }
-
+        $user = (object)$user;
         $user->table = $table;
 
         return $user;


### PR DESCRIPTION
Hi,friend
 I am a Mongo DB user.
As show in this jrean/laravel-user-verification#93 issue.
in this "UserVerification.php" file
```
    protected function getUserByEmail($email, $table)
    {
        $user = DB::table($table)
            ->where('email', $email)
            ->first();

        if ($user === null) {
            throw new UserNotFoundException();
        }
        $user->table = $table;
```
**$user is  stdClass Object when use MYSQL
$user is  Array when use MongoDB**
$user need convert from  Array to Object for MongoDB.
if someone use MYSQL this not effect.

